### PR TITLE
Change default Scoreboard-Refresh

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -8,7 +8,7 @@ Config:
   Animations:
     Rainbow-Delay: 10
     Title-Delay: 20
-  Scoreboard-Refresh: 2
+  Scoreboard-Refresh: 10
   Disabled-Worlds:
     - testWorld
     - ExampleWorld2


### PR DESCRIPTION
2 Tick scoreboard-refresh for default is too little... This cause lagg with many players
Evidence:
https://gyazo.com/3209d9357d0fb221f5536da931e66ad5

One scoreboard not need 2 ticks refresh, maybe 10 ticks... And if you have placeholder coordinates or other placeholder fast update, if not is unnecessarily fast